### PR TITLE
Fix memory leak in exception handling

### DIFF
--- a/lib/simpletal/simpleTALES.py
+++ b/lib/simpletal/simpleTALES.py
@@ -58,7 +58,7 @@ class ContextContentException(Exception):
     pass
 
 
-PATHNOTFOUNDEXCEPTION = PathNotFoundException()
+PATHNOTFOUNDEXCEPTION = PathNotFoundException
 
 
 class ContextVariable(Exception):


### PR DESCRIPTION
Currently always the same exception **instance** is raised, which leads to a memory leak.
(Propably all tracebacks are accumulated?)

This fix should resolve this.